### PR TITLE
Fixes #8

### DIFF
--- a/EntityFrameworkCore.FirebirdSql/Migrations/FbMigrationsSqlGenerator.cs
+++ b/EntityFrameworkCore.FirebirdSql/Migrations/FbMigrationsSqlGenerator.cs
@@ -325,10 +325,7 @@ namespace EntityFrameworkCore.FirebirdSql.Migrations
 					               : " NOT NULL");
 			}
 			else
-			{
-				if (!nullable)
-					builder.Append(" NOT NULL");
-
+			{				
 				if (defaultValueSql != null)
 				{
 					builder.Append(" DEFAULT ")
@@ -339,7 +336,10 @@ namespace EntityFrameworkCore.FirebirdSql.Migrations
 					var defaultValueLiteral = Dependencies.TypeMapper.GetMapping(clrType);
 					builder.Append(" DEFAULT ")
 						   .Append(defaultValueLiteral.GenerateSqlLiteral(defaultValue));
-				} 
+				}
+			
+				if (!nullable)
+					builder.Append(" NOT NULL "); 
 			} 
 		}
 


### PR DESCRIPTION
According to [the following comment on the firebirdsql tracker](http://tracker.firebirdsql.org/browse/CORE-3300?focusedCommentId=22461&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#action_22461), the DEFAULT clause must precede the column constraint.

This change ensures that the DEFAULT clause precedes the column constraint and therefore allows the update to succeed.