### PR TITLE
2.1.4 migration fixes: double quotes and drop index

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,6 @@
     <DisablePackageReferenceVersionRestrictions>true</DisablePackageReferenceVersionRestrictions>
   </PropertyGroup>
   <PropertyGroup>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 </Project>

--- a/EFCore.FirebirdSql/Migrations/FbMigrationsSqlGenerator.cs
+++ b/EFCore.FirebirdSql/Migrations/FbMigrationsSqlGenerator.cs
@@ -240,9 +240,7 @@ namespace EntityFrameworkCore.FirebirdSql.Migrations
         protected override void Generate(DropIndexOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
             builder
-                .Append("ALTER TABLE ")
-                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
-                .Append(" DROP CONSTRAINT ")
+                .Append("DROP ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
 

--- a/EFCore.FirebirdSql/Migrations/FbMigrationsSqlGenerator.cs
+++ b/EFCore.FirebirdSql/Migrations/FbMigrationsSqlGenerator.cs
@@ -240,7 +240,7 @@ namespace EntityFrameworkCore.FirebirdSql.Migrations
         protected override void Generate(DropIndexOperation operation, IModel model, MigrationCommandListBuilder builder)
         {
             builder
-                .Append("DROP ")
+                .Append("DROP INDEX ")
                 .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
 

--- a/EFCore.FirebirdSql/Migrations/Internal/FbHistoryRepository.cs
+++ b/EFCore.FirebirdSql/Migrations/Internal/FbHistoryRepository.cs
@@ -50,7 +50,7 @@ WHERE
     AND
     rdb$view_blr IS NULL
     AND
-    rdb$relation_name = '{stringTypeMapping.GenerateSqlLiteral(TableName)}'";
+    rdb$relation_name = {stringTypeMapping.GenerateSqlLiteral(TableName)}";
             }
         }
 


### PR DESCRIPTION
Fixed two migration bugs:

- Issue #47: Duplicate citation of table name in FbHistoryRepository.ExistsSql.
- Wrong DDL for DROP INDEX.

Based on 2.1.4 branch, but seems to be alright to merge into 2.2.